### PR TITLE
Fix YAM decimals for normal calls, increase minimum

### DIFF
--- a/spaces/yam/index.json
+++ b/spaces/yam/index.json
@@ -2,7 +2,7 @@
   "key": "yam",
   "name": "Yam Finance",
   "chainId": 1,
-  "decimals": 24,
+  "decimals": 18,
   "symbol": "YAM",
   "defaultView": "core",
   "address": "0x0AaCfbeC6a24756c20D41914F2caba817C0d8521",
@@ -10,7 +10,7 @@
   "core": [
     "0x683A78bA1f6b25E29fbBC9Cd1BFA29A51520De84"
   ],
-  "min": 100,
+  "min": 400,
   "invalid": [],
   "strategies": [
     ["contract-call", {


### PR DESCRIPTION
Yam has 2 sets of decimals, and snapshot uses balanceOf and doesnt strictly follow the strategy given for proposal creation. I don't know if it is desirable to separate voting power & proposal creation requirements. Likely users will want proposal creation to use voting power (as determined by the strategy), but I may be wrong. Just something to think about

This switches the decimals used, and increases the minimum.
