### PR TITLE
AdEx space: change token

### DIFF
--- a/spaces/adex/index.json
+++ b/spaces/adex/index.json
@@ -3,10 +3,10 @@
   "name": "AdEx Network",
   "chainId": 1,
   "decimals": 18,
-  "symbol": "ADX",
+  "symbol": "ADX-LOYALTY",
   "defaultView": "all",
-  "address": "0xADE00C28244d5CE17D72E40330B1c318cD12B7c3",
-  "token": "0xADE00C28244d5CE17D72E40330B1c318cD12B7c3",
+  "address": "0x49ee1555672E1b7928Fc581810B4e79dD85263E1",
+  "token": "0x49ee1555672E1b7928Fc581810B4e79dD85263E1",
   "core": [],
   "min": 0,
   "invalid": []


### PR DESCRIPTION
Changes the AdEx space to a new ADX-LOYALTY token which is a derivative of ADX (minted by joining the loyalty pool)
  
Etherscan: https://etherscan.io/address/0x49ee1555672E1b7928Fc581810B4e79dD85263E1
CoinGecko: https://www.coingecko.com/en/coins/adex
Website: https://www.adex.network
Twitter: https://twitter.com/AdExNetwork
