### PR TITLE
Revert LexDAO space to Snapshot "default" skin.scss

### DIFF
--- a/spaces/lexdao/skin.scss
+++ b/spaces/lexdao/skin.scss
@@ -1,9 +1,0 @@
-.lexdao {
-  --primary-color: #000000;
-  --bg-color: #000000;
-  --text-color: white;
-  --link-color: #ad3131;
-  --heading-color: #ad3131;
-  --border-color: #D4AF37;
-  --header-bg: #000000;
-}


### PR DESCRIPTION
remove current skin to use snapshot space default, per request of lexdao members.

