### PR TITLE
Update the ADX space again

### DIFF
--- a/spaces/adex/index.json
+++ b/spaces/adex/index.json
@@ -5,8 +5,8 @@
   "decimals": 18,
   "symbol": "ADX-LOYALTY",
   "defaultView": "all",
-  "address": "0x49ee1555672E1b7928Fc581810B4e79dD85263E1",
-  "token": "0x49ee1555672E1b7928Fc581810B4e79dD85263E1",
+  "address": "0xd9A4cB9dc9296e111c66dFACAb8Be034EE2E1c2C",
+  "token": "0xd9A4cB9dc9296e111c66dFACAb8Be034EE2E1c2C",
   "core": [],
   "min": 0,
   "invalid": []


### PR DESCRIPTION
Update the AdEx space again following a redeployment of ADX-LOYALTY

Etherscan: https://etherscan.io/address/0xd9A4cB9dc9296e111c66dFACAb8Be034EE2E1c2C
CoinGecko: https://www.coingecko.com/en/coins/adex (ADX is the underlying asset of ADX-LOYALTY)
Website: https://www.adex.network
Twitter: https://twitter.com/AdEx_Network
